### PR TITLE
Add Text Type plugin (com.frankz.texttype)

### DIFF
--- a/catalogue.json
+++ b/catalogue.json
@@ -1136,5 +1136,11 @@
 		"author": "Zoran Stefanovic",
 		"repository": "https://github.com/zoran-stefanovic/SteamScroll",
 		"description": "Plugin for Elgato Stream Deck + to scroll through installed Steam games and launch them"
+	},
+	"com.frankz.texttype": {
+		"name": "Text Type",
+		"author": "frankz",
+		"repository": "https://github.com/bloodynite/opendeck-input-text",
+		"description": "Types plain text using wtype (wlr-virtual-keyboard Wayland protocol), no enigo or libei needed"
 	}
 }


### PR DESCRIPTION
Adds [Text Type](https://github.com/bloodynite/opendeck-input-text) — an OpenDeck plugin that types plain text using wtype (wlr-virtual-keyboard Wayland protocol). No enigo or libei needed.

Plugin UUID: `com.frankz.texttype`
Repo: https://github.com/bloodynite/opendeck-input-text
Release: `.streamdeckplugin` available via GitHub Releases